### PR TITLE
set the global namespace before ElggMenuItem

### DIFF
--- a/views/default/js/roles/ui/config.php
+++ b/views/default/js/roles/ui/config.php
@@ -1,6 +1,6 @@
 <?php
 
-//namespace Elgg\Roles\UI;
+namespace Elgg\Roles\UI;
 
 // VIEWS FOR AUTOCOMPLETE
 $views = elgg_view_tree('', '');
@@ -104,7 +104,7 @@ foreach ($entities as $entity) {
 		$menu = elgg_trigger_plugin_hook('register', "menu:$menu_name", $fake_params, $items);
 
 		foreach ($menu as $item) {
-			if ($item instanceof ElggMenuItem) {
+			if ($item instanceof \ElggMenuItem) {
 				$menus_config[$menu_name][] = $item->getName();
 			}
 		}


### PR DESCRIPTION
set default namespace "\" before ElggMenuItem
